### PR TITLE
use v3trap instead of v2trap in ospf_snmp.c

### DIFF
--- a/lib/smux.h
+++ b/lib/smux.h
@@ -133,12 +133,25 @@ extern void smux_trap(struct variable *, size_t, const oid *, size_t,
 		      const oid *, size_t, const oid *, size_t,
 		      const struct trap_object *, size_t, uint8_t);
 
+extern void smux_v3trap(struct variable *, size_t, const oid *, size_t,
+		      const oid *, size_t, const oid *, size_t,
+		      const struct trap_object *, size_t, uint8_t,
+			  const char *context);
+
 extern int smux_trap_multi_index(struct variable *vp, size_t vp_len,
 				 const oid *ename, size_t enamelen,
 				 const oid *name, size_t namelen,
 				 struct index_oid *iname, size_t index_len,
 				 const struct trap_object *trapobj,
 				 size_t trapobjlen, uint8_t sptrap);
+
+extern int smux_v3trap_multi_index(struct variable *vp, size_t vp_len,
+				 const oid *ename, size_t enamelen,
+				 const oid *name, size_t namelen,
+				 struct index_oid *iname, size_t index_len,
+				 const struct trap_object *trapobj,
+				 size_t trapobjlen, uint8_t sptrap,
+				 const char *context);
 
 extern void smux_events_update(void);
 extern int oid_compare(const oid *, int, const oid *, int);


### PR DESCRIPTION
Revert "ospfd: fix some dicey pointer arith in snmp module"

This reverts commit 438ef98701e9922e81a451f87ad053268a1a557e.

send_v3trap -> send_v2trap

remove v3

copy only if args not null

Revert "remove v3"

This reverts commit c49d676aa5f3c21509e6e1f6124025034787f911.

Revert "send_v3trap -> send_v2trap"

This reverts commit a7685f3ab41e14f57212cd17b806d645ab9c2df6.